### PR TITLE
Make recursor retries configurable

### DIFF
--- a/jobs/bosh-dns-windows/spec
+++ b/jobs/bosh-dns-windows/spec
@@ -95,6 +95,9 @@ properties:
   recursor_timeout:
     description: "A timeout value for when dialing, writing and reading from the configured recursors"
     default: 2s
+  recursor_retry_count:
+    description: "Maximum number of retries for recursively resolving DNS queries"
+    default: 0
   recursor_selection:
     description: "The selection strategy for the recursors (serial or smart)"
     default: smart

--- a/jobs/bosh-dns-windows/templates/config.json.erb
+++ b/jobs/bosh-dns-windows/templates/config.json.erb
@@ -10,6 +10,7 @@
   alias_files_glob: p('alias_files_glob'),
   upcheck_domains: p('upcheck_domains'),
   recursor_timeout: p('recursor_timeout'),
+  recursor_retry_count: p('recursor_retry_count'),
   request_timeout: p('request_timeout'),
   recursor_selection: p('recursor_selection'),
   jobs_dir: '/var/vcap/jobs',

--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -102,6 +102,9 @@ properties:
   recursor_timeout:
     description: "A timeout value for when dialing, writing and reading from the configured recursors"
     default: 2s
+  recursor_retry_count:
+    description: "Maximum number of retries for recursively resolving DNS queries"
+    default: 0
   recursor_selection:
     description: "The selection strategy for the recursors (serial or smart)"
     default: smart

--- a/jobs/bosh-dns/templates/config.json.erb
+++ b/jobs/bosh-dns/templates/config.json.erb
@@ -10,6 +10,7 @@
   alias_files_glob: p('alias_files_glob'),
   upcheck_domains: p('upcheck_domains'),
   recursor_timeout: p('recursor_timeout'),
+  recursor_retry_count: p('recursor_retry_count'),
   request_timeout: p('request_timeout'),
   recursor_selection: p('recursor_selection'),
   jobs_dir: '/var/vcap/jobs',

--- a/spec/jobs/shared_examples.rb
+++ b/spec/jobs/shared_examples.rb
@@ -22,5 +22,19 @@ shared_examples_for 'common config.json' do
         end
       end
     end
+
+    context 'recursor_retry_count' do
+      it 'defaults to 0' do
+        expect(rendered['recursor_retry_count']).to eq(0)
+      end
+
+      context 'configured' do
+        let(:properties) { {'recursor_retry_count' => 3} }
+
+        it 'writes recursor_retry_count' do
+          expect(rendered['recursor_retry_count']).to eq(3)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi @HappyTobi ,

in order to make the `recursor_retry_count` property configurable from the outside, it's probably reasonable to include it in the bosh-dns job spec section of the release.

What do you think?

Co-authored-by: joergdw <joerg.weisbarth@sap.com>